### PR TITLE
Add OpenID Connect discovery and JWKS support for oauth2-proxy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The plugin provides an OpenID Connect UserInfo endpoint that returns claims abou
    - `openid` (required) - Returns the 'sub' claim with the user ID
    - `profile` - Returns profile claims (name, given_name, family_name, etc.)
    - `email` - Returns email and email_verified claims
+   - `offline_access` - Allows OIDC clients to receive a refresh token during Authorization Code flow
    - `address` - Returns address-related claims
    - `phone` - Returns phone number claims
 
@@ -370,6 +371,37 @@ User authenticates → OAuth2 access token created
 - ✅ Scope-based access: Can map OAuth2 scopes to different web services
 - ✅ Standard compliance: Supports OAuth2 and OpenID Connect flows
 - ✅ Secure: Tokens expire automatically when OAuth2 tokens expire
+
+## OpenID Connect interoperability
+
+The plugin can act as an OpenID Connect provider for clients such as oauth2-proxy.
+
+Implemented endpoints:
+
+- Authorization endpoint: `/local/oauth2/login.php`
+- Token endpoint: `/local/oauth2/token.php`
+- Refresh token endpoint: `/local/oauth2/refresh_token.php`
+- UserInfo endpoint: `/local/oauth2/userinfo.php`
+- JWKS endpoint: `/local/oauth2/jwks.php`
+- Discovery document endpoint: `/local/oauth2/openid_configuration.php`
+
+The plugin issues signed `id_token` values for Authorization Code requests that include the `openid` scope. Tokens are signed with `RS256` and include a deterministic `kid` header that matches the published JWK Set.
+
+### Discovery and standard well-known path
+
+Moodle local plugins cannot directly own the site root `/.well-known/openid-configuration` path. The plugin therefore exposes discovery metadata at `/local/oauth2/openid_configuration.php`.
+
+To support standard OIDC discovery for relying parties such as oauth2-proxy, expose the standard path through your web server or reverse proxy and rewrite it to the plugin endpoint.
+
+Example Nginx rewrite:
+
+```nginx
+location = /.well-known/openid-configuration {
+    rewrite ^ /local/oauth2/openid_configuration.php last;
+}
+```
+
+If you publish discovery through a reverse proxy, ensure the issuer configured in Moodle matches the public issuer URL exactly.
 
 ## Contributors
 Apart from people in this repository, the plugin has been created based on the [local_oauth project] (https://github.com/projectestac/moodle-local_oauth) with the following contributors:

--- a/classes/controller/authorize_controller.php
+++ b/classes/controller/authorize_controller.php
@@ -1,0 +1,128 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * OIDC authorize controller that enriches auth-code ID tokens with scoped claims.
+ *
+ * @package    local_oauth2
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_oauth2\controller;
+
+use OAuth2\OpenID\Controller\AuthorizeController as openid_authorize_controller;
+use OAuth2\OpenID\Storage\UserClaimsInterface;
+use OAuth2\ScopeInterface;
+use OAuth2\Storage\ClientInterface;
+
+/**
+ * OIDC authorize controller that includes profile/email claims in auth-code ID tokens.
+ */
+class authorize_controller extends openid_authorize_controller {
+    /**
+     * @var UserClaimsInterface
+     */
+    protected $userclaimsstorage;
+
+    /**
+     * Constructor.
+     *
+     * @param ClientInterface $clientstorage
+     * @param array $responseTypes
+     * @param array $config
+     * @param ScopeInterface|null $scopeUtil
+     * @param UserClaimsInterface $userclaimsstorage
+     */
+    public function __construct(
+        ClientInterface $clientstorage,
+        array $responseTypes,
+        array $config,
+        ?ScopeInterface $scopeUtil,
+        UserClaimsInterface $userclaimsstorage
+    ) {
+        parent::__construct($clientstorage, $responseTypes, $config, $scopeUtil);
+        $this->userclaimsstorage = $userclaimsstorage;
+    }
+
+    /**
+     * Build authorize parameters and include user claims in auth-code ID tokens.
+     *
+     * @param \OAuth2\RequestInterface $request
+     * @param \OAuth2\ResponseInterface $response
+     * @param mixed $user_id
+     * @return array|null
+     */
+    protected function buildAuthorizeParameters($request, $response, $user_id) {
+        $params = parent::buildAuthorizeParameters($request, $response, $user_id);
+        if (!$params) {
+            return null;
+        }
+
+        if ($this->needsIdToken($this->getScope())
+            && $this->getResponseType() == self::RESPONSE_TYPE_AUTHORIZATION_CODE) {
+            $claims = $this->userclaimsstorage->getUserClaims($user_id, $this->getScope());
+            $params['id_token'] = $this->responseTypes['id_token']->createIdToken(
+                $this->getClientId(),
+                $user_id,
+                $this->getNonce(),
+                $claims
+            );
+        }
+
+        return $params;
+    }
+
+    /**
+     * Validate authorize requests and require state for OIDC requests.
+     *
+     * Enforcing state for OpenID Connect code flows avoids silent consented
+     * logins being triggered cross-site for clients that rely on this endpoint
+     * for authentication.
+     *
+     * @param \OAuth2\RequestInterface $request
+     * @param \OAuth2\ResponseInterface $response
+     * @return bool
+     */
+    public function validateAuthorizeRequest($request, $response) {
+        if (!parent::validateAuthorizeRequest($request, $response)) {
+            return false;
+        }
+
+        if (!$this->needsIdToken($this->getScope()) || $this->getState()) {
+            return true;
+        }
+
+        $redirecturi = $this->getRedirectUri();
+        if (empty($redirecturi)) {
+            $clientdetails = $this->clientStorage->getClientDetails($this->getClientId());
+            $redirecturi = $clientdetails['redirect_uri'] ?? null;
+        }
+
+        if ($redirecturi) {
+            $response->setRedirect(
+                $this->config['redirect_status_code'],
+                $redirecturi,
+                null,
+                'invalid_request',
+                'The state parameter is required for OpenID Connect requests'
+            );
+        } else {
+            $response->setError(400, 'invalid_request', 'The state parameter is required for OpenID Connect requests');
+        }
+
+        return false;
+    }
+}

--- a/classes/moodle_oauth_storage.php
+++ b/classes/moodle_oauth_storage.php
@@ -879,4 +879,19 @@ class moodle_oauth_storage implements
         $alg = $DB->get_field('local_oauth2_public_key', 'encryption_algorithm', ['client_id' => '']);
         return $alg ? $alg : 'RS256';
     }
+
+    /**
+     * Get the deterministic key identifier for the signing key associated with a client.
+     *
+     * @param string|null $clientid
+     * @return string|null
+     */
+    public function getKeyId($clientid = null) {
+        $record = utils::get_signing_key_record($clientid);
+        if (!$record) {
+            return null;
+        }
+
+        return utils::get_key_id_from_public_key($record->public_key);
+    }
 }

--- a/classes/oidc_jwt.php
+++ b/classes/oidc_jwt.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * JWT helper for OIDC ID tokens with explicit kid support.
+ *
+ * @package    local_oauth2
+ * @author     Microsoft
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_oauth2;
+
+/**
+ * JWT helper for OIDC ID token signing.
+ */
+class oidc_jwt extends \OAuth2\Encryption\Jwt {
+    /**
+     * @var string|null
+     */
+    protected $keyid;
+
+    /**
+     * Encode a payload and include a kid header.
+     *
+     * @param array $payload
+     * @param string $key
+     * @param string $algorithm
+     * @param string|null $keyid
+     * @return string
+     */
+    public function encode_with_key_id(array $payload, string $key, string $algorithm = 'HS256', ?string $keyid = null): string {
+        $this->keyid = $keyid;
+
+        try {
+            return parent::encode($payload, $key, $algorithm);
+        } finally {
+            $this->keyid = null;
+        }
+    }
+
+    /**
+     * Generate a JWT header with an optional kid.
+     *
+     * @param array $payload
+     * @param string $algorithm
+     * @return array
+     */
+    protected function generateJwtHeader($payload, $algorithm) {
+        $header = parent::generateJwtHeader($payload, $algorithm);
+
+        if (!empty($this->keyid)) {
+            $header['kid'] = $this->keyid;
+        }
+
+        return $header;
+    }
+}

--- a/classes/response_type/id_token.php
+++ b/classes/response_type/id_token.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * OIDC ID token response type with kid-aware signing.
+ *
+ * @package    local_oauth2
+ * @author     Microsoft
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_oauth2\response_type;
+
+use local_oauth2\oidc_jwt;
+
+/**
+ * ID token response type that emits kid in JWT headers.
+ */
+class id_token extends \OAuth2\OpenID\ResponseType\IdToken {
+    /**
+     * Encode an ID token and add a kid header when a signing key is available.
+     *
+     * @param array $token
+     * @param string|null $client_id
+     * @return string
+     */
+    protected function encodeToken(array $token, $client_id = null) {
+        $privatekey = $this->publicKeyStorage->getPrivateKey($client_id);
+        $algorithm = $this->publicKeyStorage->getEncryptionAlgorithm($client_id);
+        $kid = method_exists($this->publicKeyStorage, 'getKeyId')
+            ? $this->publicKeyStorage->getKeyId($client_id)
+            : null;
+
+        $jwt = new oidc_jwt();
+        return $jwt->encode_with_key_id($token, $privatekey, $algorithm, $kid);
+    }
+}

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -26,11 +26,15 @@
 
 namespace local_oauth2;
 
+use local_oauth2\controller\authorize_controller as oidc_authorize_controller;
 use local_oauth2\form\authorize_form;
+use local_oauth2\response_type\id_token as oidc_id_token_response;
 use OAuth2\Autoloader;
-use OAuth2\GrantType\AuthorizationCode;
 use OAuth2\GrantType\RefreshToken;
 use OAuth2\GrantType\UserCredentials;
+use OAuth2\OpenID\GrantType\AuthorizationCode as oidc_authorization_code_grant;
+use OAuth2\OpenID\ResponseType\AuthorizationCode as oidc_authorization_code_response;
+use OAuth2\OpenID\ResponseType\CodeIdToken as oidc_code_id_token_response;
 use OAuth2\Server;
 use stdClass;
 
@@ -70,23 +74,52 @@ class utils {
         // Autoload the required files.
         require_once($CFG->dirroot . '/local/oauth2/vendor/bshaffer/oauth2-server-php/src/OAuth2/Autoloader.php');
         Autoloader::register();
+        require_once(__DIR__ . '/oidc_jwt.php');
+        require_once(__DIR__ . '/response_type/id_token.php');
+        require_once(__DIR__ . '/controller/authorize_controller.php');
 
         $storage = new moodle_oauth_storage([]);
-
-        // Pass a storage object or array of storage objects to the OAuth2 server class.
-        // Enable OpenID Connect mode to use the AuthorizeController that supports PKCE.
-        $server = new Server($storage, [
-            'use_openid_connect' => true,
-            'issuer' => $CFG->wwwroot,
-        ]);
-        $server->setConfig('enforce_state', false);
 
         // Set access token lifetime.
         $accesstokenlifetime = get_config('local_oauth2', 'access_token_lifetime');
         if (!$accesstokenlifetime) {
             $accesstokenlifetime = HOURSECS;
         }
+
+        $idtokenresponse = new oidc_id_token_response($storage, $storage, [
+            'issuer' => self::get_issuer(),
+            'id_lifetime' => intval($accesstokenlifetime),
+        ]);
+        $coderesponse = new oidc_authorization_code_response($storage);
+
+        $responseTypes = [
+            'code' => $coderesponse,
+            'id_token' => $idtokenresponse,
+            'code id_token' => new oidc_code_id_token_response($coderesponse, $idtokenresponse),
+        ];
+
+        // Pass a storage object or array of storage objects to the OAuth2 server class.
+        // Enable OpenID Connect mode to use the AuthorizeController that supports PKCE.
+        $server = new Server($storage, [
+            'use_openid_connect' => true,
+            'issuer' => self::get_issuer(),
+        ], [], $responseTypes);
+        $server->setConfig('enforce_state', false);
+        $server->setAuthorizeController(new oidc_authorize_controller(
+            $storage,
+            $responseTypes,
+            [
+                'allow_implicit' => false,
+                'enforce_state' => false,
+                'require_exact_redirect_uri' => true,
+                'enforce_pkce' => false,
+            ],
+            $server->getScopeUtil(),
+            $storage
+        ));
+
         $server->setConfig('access_lifetime', intval($accesstokenlifetime));
+        $server->setConfig('id_lifetime', intval($accesstokenlifetime));
 
         // Set refresh token lifetime.
         $refreshtokenlifetime = get_config('local_oauth2', 'refresh_token_lifetime');
@@ -96,7 +129,7 @@ class utils {
         $server->setConfig('refresh_token_lifetime', intval($refreshtokenlifetime));
 
         // Add the "Authorization Code" grant type.
-        $server->addGrantType(new AuthorizationCode($storage));
+        $server->addGrantType(new oidc_authorization_code_grant($storage));
 
         // Add the "Password" grant type (Resource Owner Password Credentials).
         $server->addGrantType(new UserCredentials($storage));
@@ -108,6 +141,203 @@ class utils {
         ]));
 
         return $server;
+    }
+
+    /**
+     * Get the public issuer URL for this provider.
+     *
+     * @return string
+     */
+    public static function get_issuer(): string {
+        global $CFG;
+
+        $issuer = trim((string) get_config('local_oauth2', 'issuer'));
+        if ($issuer === '') {
+            $issuer = $CFG->wwwroot;
+        }
+
+        return rtrim($issuer, '/');
+    }
+
+    /**
+     * Build an endpoint URL for this plugin.
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function get_endpoint_url(string $path): string {
+        return self::get_issuer() . '/local/oauth2/' . ltrim($path, '/');
+    }
+
+    /**
+     * Get a signing key record, preferring a client-specific key and falling back to the default key.
+     *
+     * @param string|null $clientid
+     * @return stdClass|null
+     */
+    public static function get_signing_key_record(?string $clientid = null): ?stdClass {
+        global $DB;
+
+        if (!empty($clientid)) {
+            $record = $DB->get_record('local_oauth2_public_key', ['client_id' => $clientid]);
+            if ($record) {
+                return $record;
+            }
+        }
+
+        $record = $DB->get_record('local_oauth2_public_key', ['client_id' => '']);
+        return $record ?: null;
+    }
+
+    /**
+     * Get all public signing key records that may be used to sign ID tokens.
+     *
+     * @return array
+     */
+    public static function get_all_signing_key_records(): array {
+        global $DB;
+
+        return $DB->get_records('local_oauth2_public_key', null, 'id ASC');
+    }
+
+    /**
+     * Create a deterministic key identifier from a PEM encoded public key.
+     *
+     * @param string $publickey
+     * @return string
+     */
+    public static function get_key_id_from_public_key(string $publickey): string {
+        return self::base64url_encode(hash('sha256', $publickey, true));
+    }
+
+    /**
+     * Convert a PEM encoded RSA public key into a JWK.
+     *
+     * @param string $publickey
+     * @param string $algorithm
+     * @param string|null $kid
+     * @return array
+     */
+    public static function convert_public_key_to_jwk(string $publickey, string $algorithm = 'RS256', ?string $kid = null): array {
+        $resource = openssl_pkey_get_public($publickey);
+        if ($resource === false) {
+            throw new \RuntimeException('Invalid RSA public key');
+        }
+
+        $details = openssl_pkey_get_details($resource);
+        if ($details === false || empty($details['rsa']['n']) || empty($details['rsa']['e'])) {
+            throw new \RuntimeException('Unable to read RSA public key details');
+        }
+
+        $jwk = [
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'alg' => $algorithm,
+            'n' => self::base64url_encode($details['rsa']['n']),
+            'e' => self::base64url_encode($details['rsa']['e']),
+        ];
+
+        if (!empty($kid)) {
+            $jwk['kid'] = $kid;
+        }
+
+        return $jwk;
+    }
+
+    /**
+     * Get the JWK set for all configured signing keys.
+     *
+     * @return array
+     */
+    public static function get_jwks(): array {
+        $keys = [];
+        $seen = [];
+
+        foreach (self::get_all_signing_key_records() as $record) {
+            $kid = self::get_key_id_from_public_key($record->public_key);
+            if (isset($seen[$kid])) {
+                continue;
+            }
+
+            $seen[$kid] = true;
+            $keys[] = self::convert_public_key_to_jwk(
+                $record->public_key,
+                $record->encryption_algorithm ?: 'RS256',
+                $kid
+            );
+        }
+
+        return ['keys' => $keys];
+    }
+
+    /**
+     * Build OIDC discovery metadata for this provider.
+     *
+     * @return array
+     */
+    public static function get_openid_configuration(): array {
+        global $DB;
+
+        $scopes = $DB->get_fieldset('local_oauth2_scope', 'scope');
+        if (empty($scopes)) {
+            $scopes = ['openid', 'profile', 'email'];
+        }
+
+        $claims = [
+            'sub',
+            'iss',
+            'aud',
+            'exp',
+            'iat',
+            'auth_time',
+            'nonce',
+            'email',
+            'email_verified',
+            'name',
+            'given_name',
+            'family_name',
+            'middle_name',
+            'nickname',
+            'preferred_username',
+            'profile',
+            'picture',
+            'website',
+            'zoneinfo',
+            'locale',
+            'updated_at',
+            'address',
+            'phone_number',
+            'phone_number_verified',
+        ];
+
+        return [
+            'issuer' => self::get_issuer(),
+            'authorization_endpoint' => self::get_endpoint_url('login.php'),
+            'token_endpoint' => self::get_endpoint_url('token.php'),
+            'userinfo_endpoint' => self::get_endpoint_url('userinfo.php'),
+            'jwks_uri' => self::get_endpoint_url('jwks.php'),
+            'response_types_supported' => ['code'],
+            'grant_types_supported' => ['authorization_code', 'refresh_token', 'password'],
+            'subject_types_supported' => ['public'],
+            'id_token_signing_alg_values_supported' => ['RS256'],
+            'token_endpoint_auth_methods_supported' => ['client_secret_basic', 'client_secret_post', 'none'],
+            'scopes_supported' => array_values($scopes),
+            'claims_supported' => $claims,
+            'code_challenge_methods_supported' => ['plain', 'S256'],
+            'claims_parameter_supported' => false,
+            'request_parameter_supported' => false,
+            'request_uri_parameter_supported' => false,
+        ];
+    }
+
+    /**
+     * Base64url encode binary data.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function base64url_encode(string $value): string {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
     }
 
     /**

--- a/db/install.php
+++ b/db/install.php
@@ -39,6 +39,7 @@ function xmldb_local_oauth2_install() {
         ['scope' => 'openid', 'is_default' => 1],
         ['scope' => 'profile', 'is_default' => 0],
         ['scope' => 'email', 'is_default' => 0],
+        ['scope' => 'offline_access', 'is_default' => 0],
         ['scope' => 'address', 'is_default' => 0],
         ['scope' => 'phone', 'is_default' => 0],
     ];

--- a/db/install.xml
+++ b/db/install.xml
@@ -51,7 +51,7 @@
                 <FIELD NAME="redirect_uri" TYPE="char" LENGTH="1333" NOTNULL="false" SEQUENCE="false"/>
                 <FIELD NAME="expires" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
                 <FIELD NAME="scope" TYPE="char" LENGTH="1333" NOTNULL="false" SEQUENCE="false"/>
-                <FIELD NAME="id_token" TYPE="char" LENGTH="1000" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="id_token" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
                 <FIELD NAME="code_challenge" TYPE="char" LENGTH="128" NOTNULL="false" SEQUENCE="false"/>
                 <FIELD NAME="code_challenge_method" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
             </FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -83,6 +83,31 @@ function xmldb_local_oauth2_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024100704, 'local', 'oauth2');
     }
 
+    if ($oldversion < 2026032300) {
+        $defaultscopes = [
+            ['scope' => 'offline_access', 'is_default' => 0],
+        ];
+
+        foreach ($defaultscopes as $scopedata) {
+            if (!$DB->record_exists('local_oauth2_scope', ['scope' => $scopedata['scope']])) {
+                $record = (object) $scopedata;
+                $DB->insert_record('local_oauth2_scope', $record);
+            }
+        }
+
+        upgrade_plugin_savepoint(true, 2026032300, 'local', 'oauth2');
+    }
+
+    if ($oldversion < 2026032301) {
+        $table = new xmldb_table('local_oauth2_authorization_code');
+
+        // Change id_token from CHAR(1000) to TEXT so OIDC code-flow tokens can include standard claims.
+        $field = new xmldb_field('id_token', XMLDB_TYPE_TEXT, null, null, null, null, null, 'scope');
+        $dbman->change_field_type($table, $field);
+
+        upgrade_plugin_savepoint(true, 2026032301, 'local', 'oauth2');
+    }
+
     if ($oldversion < 2024100705) {
         // Change public_key and private_key columns from CHAR to TEXT to accommodate RSA keys.
         $table = new xmldb_table('local_oauth2_public_key');

--- a/jwks.php
+++ b/jwks.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * JWKS endpoint.
+ *
+ * @package    local_oauth2
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core\session\manager;
+
+// phpcs:ignore moodle.Files.RequireLogin.Missing -- This is an OAuth2 endpoint, no login required.
+require_once(__DIR__ . '/../../config.php');
+
+$PAGE->set_context(context_system::instance());
+$PAGE->set_url('/local/oauth2/jwks.php');
+
+manager::write_close();
+
+header('Content-Type: application/json');
+header('Cache-Control: public, max-age=300');
+
+try {
+    echo json_encode(local_oauth2\utils::get_jwks(), JSON_UNESCAPED_SLASHES);
+} catch (Throwable $exception) {
+    debugging('local_oauth2 JWKS error: ' . $exception->getMessage(), DEBUG_DEVELOPER);
+    http_response_code(500);
+    echo json_encode([
+        'error' => 'server_error',
+        'error_description' => 'The server was unable to complete the request.',
+    ], JSON_UNESCAPED_SLASHES);
+}

--- a/lang/en/local_oauth2.php
+++ b/lang/en/local_oauth2.php
@@ -112,6 +112,8 @@ $string['settings_access_token_lifetime'] = 'Access token lifetime';
 $string['settings_access_token_lifetime_desc'] = 'The period of time that the access token is valid for';
 $string['settings_refresh_token_lifetime'] = 'Refresh token lifetime';
 $string['settings_refresh_token_lifetime_desc'] = 'The period of time that the refresh token is valid for';
+$string['settings_issuer'] = 'OIDC issuer';
+$string['settings_issuer_desc'] = 'Optional public issuer URL for OpenID Connect metadata and ID tokens. Leave empty to use Moodle\'s $CFG->wwwroot value.';
 
 // OAuth endpoints.
 $string['oauth_userinfo_endpoint'] = 'UserInfo endpoint';
@@ -121,6 +123,7 @@ $string['oauth_userinfo_endpoint_desc'] = 'Returns OpenID Connect UserInfo claim
 $string['oauth_scope_openid'] = 'OpenID authentication';
 $string['oauth_scope_profile'] = 'Profile information (name, picture, etc.)';
 $string['oauth_scope_email'] = 'Email address';
+$string['oauth_scope_offline_access'] = 'Offline access (issue refresh tokens for OpenID Connect clients)';
 $string['oauth_scope_address'] = 'Address information';
 $string['oauth_scope_phone'] = 'Phone number';
 

--- a/openid_configuration.php
+++ b/openid_configuration.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * OIDC discovery metadata endpoint.
+ *
+ * @package    local_oauth2
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use core\session\manager;
+
+// phpcs:ignore moodle.Files.RequireLogin.Missing -- This is an OAuth2 endpoint, no login required.
+require_once(__DIR__ . '/../../config.php');
+
+$PAGE->set_context(context_system::instance());
+$PAGE->set_url('/local/oauth2/openid_configuration.php');
+
+manager::write_close();
+
+header('Content-Type: application/json');
+header('Cache-Control: public, max-age=300');
+
+try {
+    echo json_encode(local_oauth2\utils::get_openid_configuration(), JSON_UNESCAPED_SLASHES);
+} catch (Throwable $exception) {
+    debugging('local_oauth2 discovery error: ' . $exception->getMessage(), DEBUG_DEVELOPER);
+    http_response_code(500);
+    echo json_encode([
+        'error' => 'server_error',
+        'error_description' => 'The server was unable to complete the request.',
+    ], JSON_UNESCAPED_SLASHES);
+}

--- a/refresh_token.php
+++ b/refresh_token.php
@@ -38,13 +38,9 @@ try {
 
     $server->handleTokenRequest($request, $response)->send();
 } catch (Exception $e) {
-    // phpcs:ignore moodle.security.outputnotprotected.exception -- This is an API endpoint, we need to return the error.
-    // Log the error to Moodle error log if debugging is enabled.
-    if (debugging('', DEBUG_DEVELOPER)) {
-        debugging('OAuth error: ' . $e->getMessage(), DEBUG_DEVELOPER);
-    }
+    debugging('local_oauth2 refresh token error: ' . $e->getMessage(), DEBUG_DEVELOPER);
 
     $response = new Response();
-    $response->setError(500, 'An unexpected error occurred: ' . $e->getMessage());
+    $response->setError(500, 'server_error', 'The server was unable to complete the request.');
     $response->send();
 }

--- a/settings.php
+++ b/settings.php
@@ -67,4 +67,15 @@ if ($hassiteconfig) {
             WEEKSECS
         )
     );
+
+    // Optional issuer override for reverse proxy or externally published OIDC metadata.
+    $settings->add(
+        new admin_setting_configtext(
+            'local_oauth2/issuer',
+            get_string('settings_issuer', 'local_oauth2'),
+            get_string('settings_issuer_desc', 'local_oauth2'),
+            '',
+            PARAM_URL
+        )
+    );
 }


### PR DESCRIPTION
## Summary

This PR adds OpenID Connect metadata and JWKS support to `moodle-local_oauth2`, making it possible to use Moodle as an OIDC provider for [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) and other standards-compliant relying parties.

With these changes, `moodle-local_oauth2` can be used to protect external applications through oauth2-proxy using OIDC discovery. For standard /.well-known/openid-configuration discovery, a reverse-proxy rewrite is required because Moodle local plugins cannot directly serve that root path:
```nginx
location = /.well-known/openid-configuration {
    rewrite ^ /local/oauth2/openid_configuration.php last;
}
```

Example oauth2-proxy configuration.

```bash
OAUTH2_PROXY_PROVIDER=oidc
OAUTH2_PROXY_OIDC_ISSUER_URL=https://moodle.example.com
OAUTH2_PROXY_CLIENT_ID=xxxxxx
OAUTH2_PROXY_CLIENT_SECRET=yyyyyy
OAUTH2_PROXY_CODE_CHALLENGE_METHOD=S256
OAUTH2_PROXY_SCOPE="openid profile email offline_access"
````

## Motivation

The plugin already provides OAuth2 and UserInfo capabilities, but it was missing a few pieces required for smooth interoperability with generic OIDC clients such as oauth2-proxy:

* OpenID Provider metadata discovery
* JWKS publication for JWT signature verification
* OIDC-oriented ID token handling with user claims
* `kid` support in JWT headers
* optional `issuer` configuration
* `offline_access` scope support for refresh-token based sessions

This PR fills those gaps while keeping the existing OAuth2 flow intact.

## What is included

* Introduced an OIDC authorize controller to enrich authorization-code ID tokens with user claims
* Added a JWT helper for OIDC ID tokens with `kid` support
* Added an ID token response type that includes `kid` in JWT headers
* Enhanced the utils class with methods for issuer URL and signing key management
* Implemented:
  * OpenID Connect discovery metadata endpoint
  * JWKS endpoint
* Updated settings to allow optional issuer configuration
* Adjusted the database schema for the `id_token` field
* Added `offline_access` scope support
* Updated README and installation files accordingly

## Result

After this change, the plugin can be consumed by oauth2-proxy through standard OIDC discovery, for example:

* discovery document exposed by the provider
* JWKS available for signature validation
* ID token returned for `openid` requests
* PKCE with `S256` supported
* refresh-token based sessions enabled through `offline_access`

## Notes

This PR is focused on interoperability with oauth2-proxy, but the changes are generic enough to improve compatibility with other OIDC clients as well.